### PR TITLE
Fix flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,9 @@ jobs:
           name: Wait for Database
           command: dockerize -wait tcp://localhost:5432 -timeout 60s
       - run:
+          name: Wait for Database User
+          command: t=30; for i in `seq $t`; do psql -h localhost -p 5432 -U ubuntu -d circle_test -c '\q' && break; [ $i -eq $t ] && return 2; sleep 1; done;
+      - run:
           name: Run Tests
           command: |
             bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/junit.xml --format progress spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
       - run:
+          name: Wait for Database
+          command: dockerize -wait tcp://localhost:5432 -timeout 60s
+      - run:
           name: Run Tests
           command: |
             bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/junit.xml --format progress spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 60s
       - run:
           name: Wait for Database User
-          command: t=30; for i in `seq $t`; do psql -h localhost -p 5432 -U ubuntu -d circle_test -c '\q' && break; [ $i -eq $t ] && return 2; sleep 1; done;
+          command: t=30; for i in `seq $t`; do psql -h localhost -p 5432 -U circleci -d circle_test -c '\q' && break; [ $i -eq $t ] && return 2; sleep 1; done;
       - run:
           name: Run Tests
           command: |


### PR DESCRIPTION
There were a lot of intermittent failures when adding ruby 3 where it seems the db has not started.

Add `dockerize -wait`

prime: @jturkel 
cc: @salsify/laser-viper 