### PR TITLE
[PIMCORE-2190] Add support for Rails 7.1, 7.2, and 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: cimg/ruby:2.7.7
+      - image: cimg/ruby:3.1.6
     working_directory: ~/activerecord-forbid_implicit_connection_checkout
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.7.7-{{ checksum "activerecord-forbid_implicit_connection_checkout.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.7.7-
+            - v1-gems-ruby-3.1.6-{{ checksum "activerecord-forbid_implicit_connection_checkout.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-3.1.6-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.7.7-{{ checksum "activerecord-forbid_implicit_connection_checkout.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-3.1.6-{{ checksum "activerecord-forbid_implicit_connection_checkout.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -33,7 +33,7 @@ jobs:
         type: string
     docker:
       - image: cimg/ruby:<< parameters.ruby_version >>
-      - image: circleci/postgres:12.9
+      - image: cimg/postgres:12.9
         environment:
           POSTGRES_USER: "circleci"
           POSTGRES_DB: "circle_test"
@@ -82,12 +82,17 @@ workflows:
           matrix:
             parameters:
               gemfile:
-                - gemfiles/rails_6.0.gemfile
-                - gemfiles/rails_6.1.gemfile
                 - gemfiles/rails_7.0.gemfile
+                - gemfiles/rails_7.1.gemfile
+                - gemfiles/rails_7.2.gemfile
+                - gemfiles/rails_8.0.gemfile
               ruby_version:
-                - 2.7.7
-                - 3.0.5
-                - 3.1.3
-                - 3.2.0
-                - 3.3.0
+                - 3.1.6
+                - 3.2.6
+                - 3.3.6
+                - 3.4.1
+            exclude:
+              - gemfile: gemfiles/rails_8.0.gemfile
+                ruby_version: 3.1.6
+              - gemfile: gemfiles/rails_7.0.gemfile
+                ruby_version: 3.4.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/**/*'

--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
-appraise 'rails-6.0' do
-  gem 'rails', '6.0.6'
-end
-
-appraise 'rails-6.1' do
-  gem 'rails', '6.1.7'
-end
-
 appraise 'rails-7.0' do
-  gem 'rails', '7.0.4'
+  gem 'rails', '~> 7.0.8'
+end
+
+appraise 'rails-7.1' do
+  gem 'rails', '~> 7.1.5'
+end
+
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.2'
+end
+
+appraise 'rails-8.0' do
+  gem 'rails', '~> 8.0.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # activerecord-forbid_implicit_checkout
 
+## v3.0.0
+- Drop support for Ruby 2.7, 3.0
+- Drop support for Rails 6.0, 6.1
+- Add support for Ruby 3.4
+- Add support for Rails 7.1, 7.2, 8.0
+
 ## v2.0.0
 - Drop support for Ruby < 2.7.
 - Drop support for Rails < 6.0.

--- a/activerecord-forbid_implicit_connection_checkout.gemspec
+++ b/activerecord-forbid_implicit_connection_checkout.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1'
 
   # Set 'allowed_push_post' to control where this gem can be published.
   if spec.respond_to?(:metadata)
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', '>= 6.0', '< 7.1'
-  spec.add_dependency 'activerecord', '>= 6.0', '< 7.1'
-  spec.add_dependency 'activesupport', '>= 6.0', '< 7.1'
+  spec.add_dependency 'activemodel', '>= 7.0', '< 8.1'
+  spec.add_dependency 'activerecord', '>= 7.0', '< 8.1'
+  spec.add_dependency 'activesupport', '>= 7.0', '< 8.1'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "6.1.7"
+gem "rails", "~> 7.1.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "6.0.6"
+gem "rails", "~> 7.2.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.8"
+gem "rails", "~> 8.0.1"
 
 gemspec path: "../"

--- a/lib/active_record/forbid_implicit_connection_checkout/version.rb
+++ b/lib/active_record/forbid_implicit_connection_checkout/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module ForbidImplicitConnectionCheckout
-    VERSION = '2.0.0'
+    VERSION = '3.0.0'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'logger'
 require 'active_record'
 require 'active_record-forbid_implicit_connection_checkout'
 require 'fileutils'
-require 'logger'
 require 'yaml'
 require 'database_cleaner'
 require 'pg'


### PR DESCRIPTION
This PR adds support for newer versions of Ruby and Rails which we'll need to update Dandelion to a newer version of Rails.

prime: @broels 

[PIMCORE-2190]

[PIMCORE-2190]: https://salsify.atlassian.net/browse/PIMCORE-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ